### PR TITLE
Don't generate the table element as the component itself; rather, wrap it in a div

### DIFF
--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -68,6 +68,6 @@ export default Ember.Component.extend({
     setOption('serverSide');
     setOption('stateSave');
 
-    this.$("table").DataTable(options);
+    this.$("table").addClass(this.get('class')).DataTable(options);
   }
 });

--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -23,6 +23,8 @@ export default Ember.Component.extend({
   serverSide: null,
   stateSave: null,
 
+  createdRow: null,
+
   didInsertElement() {
     let options = {};
 
@@ -67,6 +69,7 @@ export default Ember.Component.extend({
     setOption('searching');
     setOption('serverSide');
     setOption('stateSave');
+    setOption('createdRow');
 
     this.$("table").addClass(this.get('class')).DataTable(options);
   }

--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -4,8 +4,6 @@ import layout from '../templates/components/data-table';
 export default Ember.Component.extend({
   layout,
 
-  tagName: 'table',
-
   data: null,
   columns: null,
   columnDefs: null,
@@ -69,7 +67,7 @@ export default Ember.Component.extend({
     setOption('searching');
     setOption('serverSide');
     setOption('stateSave');
-    
-    this.$().DataTable(options);
+
+    this.$("table").DataTable(options);
   }
 });

--- a/addon/templates/components/data-table.hbs
+++ b/addon/templates/components/data-table.hbs
@@ -1,3 +1,3 @@
-<table class="display">
+<table>
   {{yield}}
 </table>

--- a/addon/templates/components/data-table.hbs
+++ b/addon/templates/components/data-table.hbs
@@ -1,1 +1,3 @@
-{{yield}}
+<table class="display">
+  {{yield}}
+</table>


### PR DESCRIPTION
I ran into an issue when one of the table cells was a link, where Ember tried to remove the component from its parent before rendering the new route and failed since DataTables introduces a wrapper div.  Wrapping the whole component in another div solves the problem.

Also, I added support for the DataTables 'createdRow' callback since I needed that for my project.